### PR TITLE
Add the Rating array

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -66,6 +66,7 @@ type Metadata struct {
 	RatingCount           int                 `json:"ratingCount"`           // music
 	RatingImage           string              `json:"ratingImage"`           // movie
 	RatingKey             string              `json:"ratingKey"`             // movie + show + music
+	Ratings               []MetadataRating    `json:"Rating"`                // movie + show
 	Role                  []MetadataItemRole  `json:"Role"`                  // movie
 	Similar               []MetadataItem      `json:"Similar"`               // movie
 	Studio                string              `json:"studio"`                // movie
@@ -234,4 +235,11 @@ type MetadataItemField struct {
 // MetadataGUID represents a ref to third-party ids, i.e. imdb and tmdb
 type MetadataGUID struct {
 	ID string `json:"id"`
+}
+
+// MetadataRating represents a rating provided by a user.
+type MetadataRating struct {
+	Image string  `json:"image"`
+	Value float64 `json:"value"`
+	Type  string  `json:"type"`
 }


### PR DESCRIPTION
- because the key is present twice, with different capitalization, if the Rating key isn't specified in the struct then the Go parser tries to parse the Rating array as a float and it errors